### PR TITLE
Add "Then > Send to > Organizer"

### DIFF
--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -14,27 +14,36 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.2'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.mozilla:rhino:1.7.14'
-    implementation 'cat.inspiracio:rhino-js-engine:1.7.10'
-    implementation 'commons-io:commons-io:2.11.0'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'net.jodah:expiringmap:0.5.10'
-    implementation 'com.miglayout:miglayout-swing:11.0'
-    implementation 'com.jayway.jsonpath:json-path:2.7.0'
-    implementation 'org.rypt:f8:1.1-RC1'
-    implementation 'org.apache.commons:commons-csv:1.9.0'
-    implementation 'com.alexandriasoftware.swing:jsplitbutton:1.3.1'
-    implementation files('libs/htmlchardet-1.0.2.1.jar')
-    implementation 'org.jsoup:jsoup:1.15.3'
-    compileOnly 'org.projectlombok:lombok:1.18.24'
+    testImplementation (
+            'junit:junit:4.13.2',
+            'org.mockito:mockito-core:4.8.0'
+    )
+
+    implementation (
+            'org.apache.httpcomponents:httpclient:4.5.13',
+            'org.mozilla:rhino:1.7.14',
+            'cat.inspiracio:rhino-js-engine:1.7.10',
+            'commons-io:commons-io:2.11.0',
+            'org.apache.commons:commons-lang3:3.12.0',
+            'net.jodah:expiringmap:0.5.10',
+            'com.miglayout:miglayout-swing:11.0',
+            'com.jayway.jsonpath:json-path:2.7.0',
+            'org.rypt:f8:1.1-RC1',
+            'org.apache.commons:commons-csv:1.9.0',
+            'com.alexandriasoftware.swing:jsplitbutton:1.3.1',
+            files('libs/htmlchardet-1.0.2.1.jar'),
+            'org.jsoup:jsoup:1.15.3',
+            'com.fasterxml.jackson.core:jackson-databind:2.14.0',
+            'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0',
+            'org.apache.commons:commons-text:1.10.0'
+    )
+
+    compileOnly (
+            'org.projectlombok:lombok:1.18.24',
+            'net.portswigger.burp.extensions:montoya-api:2023.10'
+    )
+
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
-    implementation 'net.portswigger.burp.extensions:montoya-api:2023.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0'
-    testImplementation 'org.mockito:mockito-core:4.8.0'
-    implementation 'org.apache.commons:commons-text:1.10.0'
 }
 
 jar {

--- a/extension/src/main/java/synfron/reshaper/burp/core/rules/thens/entities/sendto/SendToOption.java
+++ b/extension/src/main/java/synfron/reshaper/burp/core/rules/thens/entities/sendto/SendToOption.java
@@ -5,5 +5,6 @@ public enum SendToOption {
     Intruder,
     Repeater,
     Spider, // Unused
-    Browser
+    Browser,
+    Organizer
 }

--- a/extension/src/main/java/synfron/reshaper/burp/ui/components/rules/thens/ThenSendToComponent.java
+++ b/extension/src/main/java/synfron/reshaper/burp/ui/components/rules/thens/ThenSendToComponent.java
@@ -65,7 +65,8 @@ public class ThenSendToComponent extends ThenComponent<ThenSendToModel, ThenSend
                 List.of(overrideDefaults, sendTo),
                 () -> overrideDefaults.isSelected() && (
                         sendTo.getSelectedItem() == SendToOption.Intruder ||
-                            sendTo.getSelectedItem() == SendToOption.Repeater
+                            sendTo.getSelectedItem() == SendToOption.Repeater ||
+                                sendTo.getSelectedItem() == SendToOption.Organizer
                 )
         ), "wrap");
         mainContainer.add(ComponentVisibilityManager.withVisibilityFieldChangeDependency(
@@ -73,7 +74,8 @@ public class ThenSendToComponent extends ThenComponent<ThenSendToModel, ThenSend
                 List.of(overrideDefaults, sendTo),
                 () -> overrideDefaults.isSelected() && (
                         sendTo.getSelectedItem() == SendToOption.Intruder ||
-                                sendTo.getSelectedItem() == SendToOption.Repeater
+                            sendTo.getSelectedItem() == SendToOption.Repeater ||
+                                sendTo.getSelectedItem() == SendToOption.Organizer
                 )
         ), "wrap");
         mainContainer.add(ComponentVisibilityManager.withVisibilityFieldChangeDependency(
@@ -81,7 +83,8 @@ public class ThenSendToComponent extends ThenComponent<ThenSendToModel, ThenSend
                 List.of(overrideDefaults, sendTo),
                 () -> overrideDefaults.isSelected() && (
                         sendTo.getSelectedItem() == SendToOption.Intruder ||
-                                sendTo.getSelectedItem() == SendToOption.Repeater
+                            sendTo.getSelectedItem() == SendToOption.Repeater ||
+                                sendTo.getSelectedItem() == SendToOption.Organizer
                 )
         ), "wrap");
         mainContainer.add(ComponentVisibilityManager.withVisibilityFieldChangeDependency(
@@ -89,7 +92,8 @@ public class ThenSendToComponent extends ThenComponent<ThenSendToModel, ThenSend
                 List.of(overrideDefaults, sendTo),
                 () -> overrideDefaults.isSelected() && (
                         sendTo.getSelectedItem() == SendToOption.Intruder ||
-                                sendTo.getSelectedItem() == SendToOption.Repeater
+                            sendTo.getSelectedItem() == SendToOption.Repeater ||
+                                sendTo.getSelectedItem() == SendToOption.Organizer
                 )
         ), "wrap");
         mainContainer.add(ComponentVisibilityManager.withVisibilityFieldChangeDependency(


### PR DESCRIPTION
A user referred to this functionality in a [forum post](https://forum.portswigger.net/thread/burp-organizer-improvement-feature-81d01ae2), and I thought Reshaper would be a good fit for their use case. Unfortunately, there wasn't support for Organizer, as this API functionality was added in our 2023.10 release of the Montoya API.

I've added this functionality in and updated the Montoya API version. However, there may be some incompatibilities with `Runner`, as that is still on the older version of the API.

Please let me know if there are any issues, or if there's something I've missed 😄 