### PR TITLE
append new note if exist note on ThenComment.java

### DIFF
--- a/extension/src/main/java/synfron/reshaper/burp/core/rules/thens/ThenComment.java
+++ b/extension/src/main/java/synfron/reshaper/burp/core/rules/thens/ThenComment.java
@@ -19,8 +19,16 @@ public class ThenComment extends Then<ThenComment> implements IHttpRuleOperation
         boolean hasError = true;
         try {
             if (eventInfo.getAnnotations() != null) {
-                eventInfo.getAnnotations().setNotes(text.getText(eventInfo));
-                hasError = false;
+                if (!eventInfo.getAnnotations().notes().isEmpty()) {
+                    if (!eventInfo.getAnnotations().notes().toLowerCase().contains(text.getText(eventInfo).toLowerCase())) {
+                        eventInfo.getAnnotations().setNotes(eventInfo.getAnnotations().notes() + " , " + text.getText(eventInfo));
+                    }
+                    hasError = false;
+                }
+                else {
+                    eventInfo.getAnnotations().setNotes(text.getText(eventInfo));
+                    hasError = false;
+                }
             }
         } finally {
             if (eventInfo.getDiagnostics().isEnabled()) eventInfo.getDiagnostics().logValue(this, hasError, VariableString.getTextOrDefault(eventInfo, text, null));


### PR DESCRIPTION
If there is already a note, it will be append to the note.
Also, this feature has been added that if two triggers are activated on a request, the notes of both triggers are written on the request.

But before, only one trigger note was applied to each request.