### PR TITLE
fix NullPointerException

### DIFF
--- a/extension/src/main/java/synfron/reshaper/burp/core/messages/ContentType.java
+++ b/extension/src/main/java/synfron/reshaper/burp/core/messages/ContentType.java
@@ -54,6 +54,9 @@ public class ContentType {
     }
 
     public static ContentType get(burp.api.montoya.http.message.ContentType contentType) {
+        if (contentType == null) {
+            return Unknown;
+        }
         return switch (contentType) {
             case AMF -> Amf;
             case XML -> Xml;

--- a/extension/src/main/java/synfron/reshaper/burp/core/messages/entities/http/HttpRequestMessage.java
+++ b/extension/src/main/java/synfron/reshaper/burp/core/messages/entities/http/HttpRequestMessage.java
@@ -50,6 +50,7 @@ public class HttpRequestMessage extends HttpEntity {
 
     private void initialize() {
         if (!initialized) {
+            initialized = true;
             if (httpRequest == null) {
                 sanityCheckHeaders();
                 httpRequest = HttpRequest.httpRequest(ByteArray.byteArray(request));
@@ -57,7 +58,6 @@ public class HttpRequestMessage extends HttpEntity {
             if (!encoder.isUseDefault() && encoder.isAutoSet() && !getContentType().isTextBased()) {
                 encoder.setEncoding("default", true);
             }
-            initialized = true;
         }
     }
 


### PR DESCRIPTION
Rectifying the NullPointerException error encountered within the latest version of Burp.

```
java.lang.NullPointerException
	at synfron.reshaper.burp.core.messages.entities.http.HttpRequestMessage.getContentType(HttpRequestMessage.java:79)
	at synfron.reshaper.burp.core.messages.entities.http.HttpRequestMessage.initialize(HttpRequestMessage.java:57)
```